### PR TITLE
feat(web): add reboot button to setup page

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [env:esp32dev]
 custom_project_name = BLFLC
 custom_project_codename = Baldrick
-custom_version = 3.0.1 #BLFLC_[Major].[Minor].[Patch]
+custom_version = 3.1.0 #BLFLC_[Major].[Minor].[Patch]
 platform = espressif32
 board = esp32dev
 framework = arduino

--- a/src/blflc/web-server.cpp
+++ b/src/blflc/web-server.cpp
@@ -567,6 +567,19 @@ void handleFactoryReset(AsyncWebServerRequest *request)
     restartRequestTime = millis();
 }
 
+void handleReboot(AsyncWebServerRequest *request)
+{
+    if (!isAuthorized(request))
+        return request->requestAuthentication();
+
+    LogSerial.println(F("[Reboot] User requested reboot..."));
+
+    request->send(200, "text/plain", "Rebooting...");
+
+    shouldRestart = true;
+    restartRequestTime = millis();
+}
+
 void handleUploadConfigFileData(AsyncWebServerRequest *request, const String &filename,
                                 size_t index, uint8_t *data, size_t len, bool final)
 {
@@ -651,6 +664,7 @@ void setupWebserver()
     webServer.on("/webserial", HTTP_GET, handleWebSerialPage);
     webServer.on("/printerList", HTTP_GET, handlePrinterList);
     webServer.on("/factoryreset", HTTP_GET, handleFactoryReset);
+    webServer.on("/reboot", HTTP_GET, handleReboot);
     webServer.on("/api/ledtest", HTTP_POST, handleLedTest);
     webServer.on("/configrestore", HTTP_POST, [](AsyncWebServerRequest *request)
                  {

--- a/src/www/setupPage.html
+++ b/src/www/setupPage.html
@@ -601,6 +601,7 @@
                         <button type="button" onclick="location.href='/fwupdate'">Firmware Update</button>
                         <button type="button" onclick="location.href='/backuprestore'">backup & Restore</button>
                         <button type="button" onclick="window.open('/webserial','_blank')">Web Serial Log</button>
+                        <button type="button" style="background-color: #dc3545;" onclick="confirmReboot()">Reboot Device</button>
                     </div>
                 </details>
                 <button type="submit">Save Configuration</button>
@@ -967,6 +968,33 @@ function testLeds() {
     };
     xhr.open('POST', '/api/ledtest', true);
     xhr.send();
+}
+
+// Reboot device function
+function confirmReboot() {
+    if (confirm("Are you sure you want to reboot the device?")) {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+                if (xhr.status === 200) {
+                    alertToast("info", "Rebooting device...");
+                    setTimeout(function() {
+                        location.reload();
+                    }, 5000);
+                } else {
+                    alertToast("error", "Failed to reboot device");
+                }
+            }
+        };
+        xhr.onerror = function() {
+            alertToast("info", "Device is rebooting...");
+            setTimeout(function() {
+                location.reload();
+            }, 5000);
+        };
+        xhr.open('GET', '/reboot', true);
+        xhr.send();
+    }
 }
 
         window.onload = function () {


### PR DESCRIPTION
Add a device reboot option to the Tools section of the setup page. The button requires user confirmation before triggering a reboot via the new /reboot endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)