### PR TITLE
feat(led): add RGBW color order and clock pin configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,13 +11,14 @@
 [env:esp32dev]
 custom_project_name = BLFLC
 custom_project_codename = Baldrick
-custom_version = 3.1.0 #BLFLC_[Major].[Minor].[Patch]
+custom_version = 3.2.0 #BLFLC_[Major].[Minor].[Patch]
 platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 board_build.filesystem = littlefs
+board_build.partitions = min_spiffs.csv
 build_flags =
 	-DVERSION=${this.custom_version}
 	-DSTRVERSION=\""${this.custom_version}"\"

--- a/src/blflc/filesystem.cpp
+++ b/src/blflc/filesystem.cpp
@@ -90,10 +90,10 @@ void saveFileSystem()
     // LED Hardware Configuration
     json["ledChipType"] = printerConfig.ledConfig.chipType;
     json["ledColorOrder"] = printerConfig.ledConfig.colorOrder;
+    json["ledWPlacement"] = printerConfig.ledConfig.wPlacement;
     json["ledCount"] = printerConfig.ledConfig.ledCount;
     json["ledDataPin"] = printerConfig.ledConfig.dataPin;
     json["ledClockPin"] = printerConfig.ledConfig.clockPin;
-    json["ledIsRGBW"] = printerConfig.ledConfig.isRGBW;
 
     // Pattern settings
     json["runningPattern"] = printerConfig.runningPattern;
@@ -229,10 +229,10 @@ void loadFileSystem()
         // LED Hardware Configuration (with defaults for migration)
         printerConfig.ledConfig.chipType = json["ledChipType"] | CHIP_WS2812B;
         printerConfig.ledConfig.colorOrder = json["ledColorOrder"] | ORDER_GRB;
+        printerConfig.ledConfig.wPlacement = json["ledWPlacement"] | W_PLACEMENT_3;
         printerConfig.ledConfig.ledCount = json["ledCount"] | 30;
         printerConfig.ledConfig.dataPin = json["ledDataPin"] | 16;
         printerConfig.ledConfig.clockPin = json["ledClockPin"] | 0;
-        printerConfig.ledConfig.isRGBW = json["ledIsRGBW"] | false;
 
         // Pattern settings (with defaults for migration)
         printerConfig.runningPattern = json["runningPattern"] | PATTERN_SOLID;

--- a/src/blflc/leds.h
+++ b/src/blflc/leds.h
@@ -41,12 +41,23 @@ void setRelayState(bool on);
 // Color conversion
 COLOR hex2rgb(String hex);
 
+// Helper to convert WhitePlacement enum to FastLED EOrderW
+inline EOrderW getEOrderW(uint8_t wPlacement) {
+    switch (wPlacement) {
+        case W_PLACEMENT_0: return W0;
+        case W_PLACEMENT_1: return W1;
+        case W_PLACEMENT_2: return W2;
+        case W_PLACEMENT_3: return W3;
+        default: return W3;
+    }
+}
+
 // LED setup functions
 template<uint8_t DATA_PIN>
-void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder);
+void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder, uint8_t wPlacement);
 
 template<uint8_t DATA_PIN, uint8_t CLOCK_PIN>
-void addLedsAPA102(uint16_t count);
+void addLedsAPA102(uint16_t count, uint8_t colorOrder);
 
 void setupLeds();
 
@@ -84,9 +95,43 @@ void updateleds();
 // Main LED loop
 void ledsloop();
 
+// Helper macro to add RGBW LEDs with specific color order and white placement
+#define ADD_LEDS_RGBW(CHIP, PIN, ORDER, WPLACE) \
+    FastLED.addLeds<CHIP, PIN, ORDER>(leds, count).setRgbw(Rgbw(kRGBWDefaultColorTemp, kRGBWExactColors, WPLACE))
+
 // Template implementations must remain in header
+// Note: Color order selection is only fully supported for RGBW chips.
+// For non-RGBW chips, most use GRB (the default for WS2812B/SK6812).
 template<uint8_t DATA_PIN>
-void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder) {
+void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder, uint8_t wPlacement) {
+    EOrderW wOrder = getEOrderW(wPlacement);
+
+    // Handle RGBW chip types with full color order and W placement support
+    if (chipType == CHIP_SK6812_RGBW) {
+        switch (colorOrder) {
+            case ORDER_RGB: ADD_LEDS_RGBW(SK6812, DATA_PIN, RGB, wOrder); break;
+            case ORDER_RBG: ADD_LEDS_RGBW(SK6812, DATA_PIN, RBG, wOrder); break;
+            case ORDER_GBR: ADD_LEDS_RGBW(SK6812, DATA_PIN, GBR, wOrder); break;
+            case ORDER_BRG: ADD_LEDS_RGBW(SK6812, DATA_PIN, BRG, wOrder); break;
+            case ORDER_BGR: ADD_LEDS_RGBW(SK6812, DATA_PIN, BGR, wOrder); break;
+            default: ADD_LEDS_RGBW(SK6812, DATA_PIN, GRB, wOrder); break;
+        }
+        return;
+    }
+
+    if (chipType == CHIP_WS2814_RGBW) {
+        switch (colorOrder) {
+            case ORDER_GRB: ADD_LEDS_RGBW(WS2811, DATA_PIN, GRB, wOrder); break;
+            case ORDER_RBG: ADD_LEDS_RGBW(WS2811, DATA_PIN, RBG, wOrder); break;
+            case ORDER_GBR: ADD_LEDS_RGBW(WS2811, DATA_PIN, GBR, wOrder); break;
+            case ORDER_BRG: ADD_LEDS_RGBW(WS2811, DATA_PIN, BRG, wOrder); break;
+            case ORDER_BGR: ADD_LEDS_RGBW(WS2811, DATA_PIN, BGR, wOrder); break;
+            default: ADD_LEDS_RGBW(WS2811, DATA_PIN, RGB, wOrder); break;
+        }
+        return;
+    }
+
+    // Handle non-RGBW chip types (GRB is most common default)
     switch (chipType) {
         case CHIP_WS2812B:
             FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, count);
@@ -94,17 +139,11 @@ void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder) {
         case CHIP_SK6812:
             FastLED.addLeds<SK6812, DATA_PIN, GRB>(leds, count);
             break;
-        case CHIP_SK6812_RGBW:
-            FastLED.addLeds<SK6812, DATA_PIN, GRB>(leds, count).setRgbw();
-            break;
         case CHIP_WS2811:
             FastLED.addLeds<WS2811, DATA_PIN, GRB>(leds, count);
             break;
         case CHIP_NEOPIXEL:
             FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, count);
-            break;
-        case CHIP_WS2814_RGBW:
-            FastLED.addLeds<WS2811, DATA_PIN, RGB>(leds, count).setRgbw(Rgbw(4000, kRGBWExactColors, W0));
             break;
         default:
             FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, count);
@@ -113,7 +152,7 @@ void addLedsForChipType(uint8_t chipType, uint16_t count, uint8_t colorOrder) {
 }
 
 template<uint8_t DATA_PIN, uint8_t CLOCK_PIN>
-void addLedsAPA102(uint16_t count) {
+void addLedsAPA102(uint16_t count, uint8_t colorOrder) {
     FastLED.addLeds<APA102, DATA_PIN, CLOCK_PIN, BGR>(leds, count);
 }
 

--- a/src/blflc/types.h
+++ b/src/blflc/types.h
@@ -17,18 +17,23 @@ extern "C"
         CHIP_WS2814_RGBW = 6
     };;
 
-    // Color order options
+    // Color order options (RGB channel arrangement)
     enum LedColorOrder {
         ORDER_GRB = 0,   // WS2812B default
         ORDER_RGB = 1,
         ORDER_BRG = 2,
         ORDER_RBG = 3,
         ORDER_BGR = 4,
-        ORDER_GBR = 5,
-        ORDER_GRBW = 6,  // SK6812 RGBW
-        ORDER_RGBW = 7,
-        ORDER_RWGB = 8   // WS2814 RGBW
-    };;
+        ORDER_GBR = 5
+    };
+
+    // White channel placement for RGBW strips (maps to FastLED EOrderW)
+    enum WhitePlacement {
+        W_PLACEMENT_0 = 0,  // W is 1st byte
+        W_PLACEMENT_1 = 1,  // W is 2nd byte
+        W_PLACEMENT_2 = 2,  // W is 3rd byte
+        W_PLACEMENT_3 = 3   // W is 4th byte (default)
+    };
 
     // LED pattern effects
     enum LedPattern {
@@ -50,10 +55,10 @@ extern "C"
     typedef struct LedConfigStruct {
         uint8_t chipType = CHIP_WS2812B;
         uint8_t colorOrder = ORDER_GRB;
+        uint8_t wPlacement = W_PLACEMENT_3;  // W channel position for RGBW strips
         uint16_t ledCount = 30;
         uint8_t dataPin = 16;
         uint8_t clockPin = 0;  // For APA102 only
-        bool isRGBW = false;
     } LedConfig;
 
 

--- a/src/blflc/web-server.cpp
+++ b/src/blflc/web-server.cpp
@@ -106,8 +106,10 @@ void handleGetConfig(AsyncWebServerRequest *request)
     // LED Hardware Configuration
     doc["ledChipType"] = printerConfig.ledConfig.chipType;
     doc["ledColorOrder"] = printerConfig.ledConfig.colorOrder;
+    doc["ledWPlacement"] = printerConfig.ledConfig.wPlacement;
     doc["ledCount"] = printerConfig.ledConfig.ledCount;
     doc["ledDataPin"] = printerConfig.ledConfig.dataPin;
+    doc["ledClockPin"] = printerConfig.ledConfig.clockPin;
     doc["progressBarEnabled"] = printerConfig.progressBarEnabled;
     doc["progressBgRGB"] = printerConfig.progressBarBackground.RGBhex;
 
@@ -282,6 +284,7 @@ void handleSubmitConfig(AsyncWebServerRequest *request)
     // LED Hardware Configuration
     printerConfig.ledConfig.chipType = getSafeParamInt(request, "ledChipType", CHIP_WS2812B);
     printerConfig.ledConfig.colorOrder = getSafeParamInt(request, "ledColorOrder", ORDER_GRB);
+    printerConfig.ledConfig.wPlacement = getSafeParamInt(request, "ledWPlacement", W_PLACEMENT_3);
     printerConfig.ledConfig.ledCount = constrain(getSafeParamInt(request, "ledCount", 30), 1, 300);
     printerConfig.ledConfig.dataPin = getSafeParamInt(request, "ledDataPin", 16);
     printerConfig.ledConfig.clockPin = getSafeParamInt(request, "ledClockPin", 0);

--- a/src/www/setupPage.html
+++ b/src/www/setupPage.html
@@ -99,7 +99,7 @@
                         <br>
                         <div class="input-group">
                             <label for="ledChipType">LED Type</label>
-                            <select id="ledChipType" name="ledChipType">
+                            <select id="ledChipType" name="ledChipType" onchange="updateChipTypeOptions();">
                                 <option value="3">APA102</option>
                                 <option value="5">NeoPixel</option>
                                 <option value="1">SK6812</option>
@@ -111,18 +111,25 @@
                         </div>
                         <div class="input-group">
                             <label for="ledColorOrder">Color Order</label>
-                            <select id="ledColorOrder" name="ledColorOrder">
+                            <select id="ledColorOrder" name="ledColorOrder" onchange="updateWPlacement()">
                                 <option value="0">GRB</option>
                                 <option value="1">RGB</option>
                                 <option value="2">BRG</option>
                                 <option value="3">RBG</option>
                                 <option value="4">BGR</option>
                                 <option value="5">GBR</option>
-                                <option value="6">GRBW</option>
-                                <option value="7">RGBW</option>
-                                <option value="8">RWGB</option>
                             </select>
                         </div>
+                        <div class="input-group" id="whiteSwapGroup" style="display: none;">
+                            <label for="ledWhiteSwap">Swap White Channel</label>
+                            <select id="ledWhiteSwap" name="ledWhiteSwap" onchange="updateWPlacement()">
+                                <option value="none">None (W is 4th channel)</option>
+                                <option value="R">W & R</option>
+                                <option value="G">W & G</option>
+                                <option value="B">W & B</option>
+                            </select>
+                        </div>
+                        <input type="hidden" id="ledWPlacement" name="ledWPlacement" value="3">
                         <div class="input-group">
                             <label for="ledCount">Number of LEDs (1-300)</label>
                             <input type="number" id="ledCount" name="ledCount" min="1" max="300" value="30">
@@ -132,11 +139,24 @@
                             <select id="ledDataPin" name="ledDataPin">
                                 <option value="2">GPIO 2</option>
                                 <option value="4">GPIO 4</option>
-                                <option value="5">GPIO 4</option>
+                                <option value="5">GPIO 5</option>
                                 <option value="12">GPIO 12</option>
                                 <option value="13">GPIO 13</option>
                                 <option value="16" selected>GPIO 16</option>
                                 <option value="17">GPIO 17</option>
+                                <option value="18">GPIO 18</option>
+                            </select>
+                        </div>
+                        <div class="input-group" id="clockPinGroup" style="display: none;">
+                            <label for="ledClockPin">Clock Pin (GPIO)</label>
+                            <select id="ledClockPin" name="ledClockPin">
+                                <option value="2">GPIO 2</option>
+                                <option value="4">GPIO 4</option>
+                                <option value="5">GPIO 5</option>
+                                <option value="12">GPIO 12</option>
+                                <option value="13">GPIO 13</option>
+                                <option value="16">GPIO 16</option>
+                                <option value="17" selected>GPIO 17</option>
                                 <option value="18">GPIO 18</option>
                             </select>
                         </div>
@@ -809,6 +829,90 @@
                 div.style.display = 'none';
             }
         }
+        // Check if the selected LED chip type is RGBW
+        function isRgbwChipType() {
+            const chipType = parseInt(document.getElementById('ledChipType').value);
+            // CHIP_SK6812_RGBW = 2, CHIP_WS2814_RGBW = 6
+            return chipType === 2 || chipType === 6;
+        }
+
+        // Check if the selected LED chip type is APA102 (requires clock pin)
+        function isApa102ChipType() {
+            const chipType = parseInt(document.getElementById('ledChipType').value);
+            // CHIP_APA102 = 3
+            return chipType === 3;
+        }
+
+        // Update visibility of chip-type-specific options
+        function updateChipTypeOptions() {
+            // Show/hide white channel swap for RGBW chips
+            const whiteSwapGroup = document.getElementById('whiteSwapGroup');
+            if (isRgbwChipType()) {
+                whiteSwapGroup.style.display = '';
+            } else {
+                whiteSwapGroup.style.display = 'none';
+                document.getElementById('ledWhiteSwap').value = 'none';
+                document.getElementById('ledWPlacement').value = '3';
+            }
+
+            // Show/hide clock pin for APA102
+            const clockPinGroup = document.getElementById('clockPinGroup');
+            if (isApa102ChipType()) {
+                clockPinGroup.style.display = '';
+            } else {
+                clockPinGroup.style.display = 'none';
+            }
+        }
+
+        // Color order position lookup tables
+        // Each color order defines positions: [R_pos, G_pos, B_pos]
+        const colorOrderPositions = {
+            0: { R: 1, G: 0, B: 2 }, // GRB: G=0, R=1, B=2
+            1: { R: 0, G: 1, B: 2 }, // RGB: R=0, G=1, B=2
+            2: { R: 1, G: 2, B: 0 }, // BRG: B=0, R=1, G=2
+            3: { R: 0, G: 2, B: 1 }, // RBG: R=0, B=1, G=2
+            4: { R: 2, G: 1, B: 0 }, // BGR: B=0, G=1, R=2
+            5: { R: 2, G: 0, B: 1 }  // GBR: G=0, B=1, R=2
+        };
+
+        // Compute wPlacement (W0-W3) from color order and swap selection
+        function updateWPlacement() {
+            const colorOrder = parseInt(document.getElementById('ledColorOrder').value);
+            const swapWith = document.getElementById('ledWhiteSwap').value;
+
+            let wPlacement = 3; // Default: W is 4th channel
+
+            if (swapWith !== 'none' && colorOrderPositions[colorOrder]) {
+                const positions = colorOrderPositions[colorOrder];
+                wPlacement = positions[swapWith]; // Get position of the color being swapped with W
+            }
+
+            document.getElementById('ledWPlacement').value = wPlacement;
+        }
+
+        // Reverse: set swap dropdown from wPlacement value (for loading config)
+        function setSwapFromWPlacement(colorOrder, wPlacement) {
+            if (wPlacement === 3) {
+                document.getElementById('ledWhiteSwap').value = 'none';
+                return;
+            }
+
+            const positions = colorOrderPositions[colorOrder];
+            if (!positions) {
+                document.getElementById('ledWhiteSwap').value = 'none';
+                return;
+            }
+
+            // Find which color (R, G, or B) is at the wPlacement position
+            for (const [color, pos] of Object.entries(positions)) {
+                if (pos === wPlacement) {
+                    document.getElementById('ledWhiteSwap').value = color;
+                    return;
+                }
+            }
+            document.getElementById('ledWhiteSwap').value = 'none';
+        }
+
         function hasP1() {
             if (document.getElementById('p1Printer').checked) {
                 document.getElementById("doorSwitch").checked = false;
@@ -867,8 +971,15 @@ function updateConfig() {
                     // LED Strip Configuration
                     document.getElementById('ledChipType').value = getSafeNumber(configData.ledChipType, 0);
                     document.getElementById('ledColorOrder').value = getSafeNumber(configData.ledColorOrder, 0);
+                    var wPlacement = getSafeNumber(configData.ledWPlacement, 3);
+                    document.getElementById('ledWPlacement').value = wPlacement;
+                    // Set the swap dropdown based on color order and wPlacement
+                    setSwapFromWPlacement(getSafeNumber(configData.ledColorOrder, 0), wPlacement);
                     document.getElementById('ledCount').value = getSafeNumber(configData.ledCount, 30);
                     document.getElementById('ledDataPin').value = getSafeNumber(configData.ledDataPin, 16);
+                    document.getElementById('ledClockPin').value = getSafeNumber(configData.ledClockPin, 17);
+                    // Update chip-type-specific option visibility
+                    updateChipTypeOptions();
                     document.getElementById('progressBarEnabled').checked = configData.progressBarEnabled !== false;
                     document.getElementById('progressBgRGB').value = configData.progressBgRGB || '#000000';
 


### PR DESCRIPTION
Implement WLED-style color order configuration for RGBW LED strips with separate white channel placement. Add configurable clock pin for APA102.

- Add WhitePlacement enum for W channel position (W0-W3)
- Add wPlacement field to LedConfig, remove deprecated isRGBW field
- Support all 6 RGB color orders with configurable W placement for RGBW
- Add "Swap White Channel" dropdown in web UI (visible for RGBW chips)
- Add clock pin dropdown for APA102 LEDs (hidden for other chips)
- Use min_spiffs partition scheme for additional flash space
- Fix GPIO 5 typo in data pin dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)