### PR TITLE
fix(mqtt): infer printer state from progress for P1 printers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = esp32dev, esp32_eth_gledopto, esp32_eth_iotorero
 [env:esp32dev]
 custom_project_name = BLFLC
 custom_project_codename = Baldrick
-custom_version = 3.3.1 #BLFLC_[Major].[Minor].[Patch]
+custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -43,7 +43,7 @@ lib_deps =
 [env:esp32_eth_gledopto]
 custom_project_name = BLFLC-ETH-Gledopto
 custom_project_codename = Baldrick-ETH
-custom_version = 3.3.1 #BLFLC_[Major].[Minor].[Patch]
+custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -80,7 +80,7 @@ lib_deps =
 [env:esp32_eth_iotorero]
 custom_project_name = BLFLC-ETH-IoTorero
 custom_project_codename = Baldrick-ETH
-custom_version = 3.3.1 #BLFLC_[Major].[Minor].[Patch]
+custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
 platform = espressif32
 board = esp32dev
 framework = arduino


### PR DESCRIPTION
P1 printers send mc_percent but not gcode_state in MQTT messages, causing the LED status to remain stuck on "Booting". This fix infers:
- RUNNING state when progress is 1-99%
- FINISH state when progress reaches 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)