### PR TITLE
refactor(build): optimize platformio.ini and add hardware defaults

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,20 +1,20 @@
 ; PlatformIO Project Configuration File
 ;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
+; Uses inheritance to reduce duplication:
+;   [env]           - Base config for ALL environments
+;   [ethernet_base] - Shared Ethernet settings (extended by Ethernet envs)
 ;
-; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
 default_envs = esp32dev, esp32_eth_gledopto, esp32_eth_iotorero
 
-[env:esp32dev]
-custom_project_name = BLFLC
-custom_project_codename = Baldrick
-custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
+; =============================================================================
+; Base configuration - inherited by ALL environments
+; =============================================================================
+[env]
+custom_version = 3.3.2
+
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -22,13 +22,20 @@ monitor_speed = 115200
 upload_speed = 921600
 board_build.filesystem = littlefs
 board_build.partitions = min_spiffs.csv
+
 build_flags =
 	-DVERSION=${this.custom_version}
 	-DSTRVERSION=\""${this.custom_version}"\"
 	-DCONFIG_ASYNC_TCP_STACK_SIZE=4096
+	; Hardware defaults (can be overridden per-environment)
+	-DDEFAULT_LED_PIN=16
+	-DDEFAULT_RELAY_PIN=-1
+	-DDEFAULT_RELAY_INVERTED=false
+
 extra_scripts =
 	pre:pre_build.py
 	merge_firmware.py
+
 lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	knolleary/pubsubclient@2.8.0
@@ -37,78 +44,58 @@ lib_deps =
 	ESP32Async/ESPAsyncWebServer
 	mathieucarbou/MycilaWebSerial@^8.1.1
 	fastled/FastLED@^3.7.7
+
+; =============================================================================
+; WiFi build (default)
+; =============================================================================
+[env:esp32dev]
+custom_project_name = BLFLC
+
+lib_deps =
+	${env.lib_deps}
 	https://github.com/improv-wifi/sdk-cpp.git#v1.2.5
 
-; Ethernet build for Gledopto Elite 2D/4D-EXMU (LAN8720A PHY)
-[env:esp32_eth_gledopto]
-custom_project_name = BLFLC-ETH-Gledopto
-custom_project_codename = Baldrick-ETH
-custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
-board_build.filesystem = littlefs
-board_build.partitions = min_spiffs.csv
+; =============================================================================
+; Ethernet base configuration (extended by Ethernet environments)
+; =============================================================================
+[ethernet_base]
 build_flags =
-	-DVERSION=${this.custom_version}
-	-DSTRVERSION=\""${this.custom_version}"\"
-	-DCONFIG_ASYNC_TCP_STACK_SIZE=4096
-	; Ethernet configuration
+	${env.build_flags}
 	-DUSE_ETHERNET
 	-DETH_PHY_TYPE=ETH_PHY_LAN8720
 	-DETH_PHY_ADDR=1
 	-DETH_PHY_MDC=23
+
+; =============================================================================
+; Ethernet build for Gledopto Elite 2D/4D-EXMU (LAN8720A PHY)
+; =============================================================================
+[env:esp32_eth_gledopto]
+extends = ethernet_base
+custom_project_name = BLFLC-ETH-Gledopto
+
+build_flags =
+	${ethernet_base.build_flags}
 	-DETH_PHY_MDIO=33
 	-DETH_PHY_POWER=5
 	-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN
-extra_scripts =
-	pre:pre_build.py
-	merge_firmware.py
-lib_deps =
-	bblanchon/ArduinoJson@7.4.2
-	knolleary/pubsubclient@2.8.0
-	luc-github/ESP32SSDP@1.2.1
-	ESP32Async/AsyncTCP
-	ESP32Async/ESPAsyncWebServer
-	mathieucarbou/MycilaWebSerial@^8.1.1
-	fastled/FastLED@^3.7.7
-	; Note: improv-wifi not needed for ethernet builds
+	; Gledopto hardware defaults
+	-DDEFAULT_LED_PIN=16
+	-DDEFAULT_RELAY_PIN=18
+	-DDEFAULT_RELAY_INVERTED=true
 
-
+; =============================================================================
+; Ethernet build for IoTorero ESP32 ETH
+; =============================================================================
 [env:esp32_eth_iotorero]
+extends = ethernet_base
 custom_project_name = BLFLC-ETH-IoTorero
-custom_project_codename = Baldrick-ETH
-custom_version = 3.3.2 #BLFLC_[Major].[Minor].[Patch]
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
-board_build.filesystem = littlefs
-board_build.partitions = min_spiffs.csv
+
 build_flags =
-	-DVERSION=${this.custom_version}
-	-DSTRVERSION=\""${this.custom_version}"\"
-	-DCONFIG_ASYNC_TCP_STACK_SIZE=4096
-	; Ethernet configuration
-	-DUSE_ETHERNET
-	-DETH_PHY_TYPE=ETH_PHY_LAN8720
-	-DETH_PHY_ADDR=1
-	-DETH_PHY_MDC=23
+	${ethernet_base.build_flags}
 	-DETH_PHY_MDIO=18
 	-DETH_PHY_POWER=-1
 	-DETH_CLK_MODE=ETH_CLOCK_GPIO17_OUT
-extra_scripts =
-	pre:pre_build.py
-	merge_firmware.py
-lib_deps =
-	bblanchon/ArduinoJson@7.4.2
-	knolleary/pubsubclient@2.8.0
-	luc-github/ESP32SSDP@1.2.1
-	ESP32Async/AsyncTCP
-	ESP32Async/ESPAsyncWebServer
-	mathieucarbou/MycilaWebSerial@^8.1.1
-	fastled/FastLED@^3.7.7
-	; Note: improv-wifi not needed for ethernet builds
+	; IoTorero hardware defaults
+	-DDEFAULT_LED_PIN=5
+	-DDEFAULT_RELAY_PIN=2
+	-DDEFAULT_RELAY_INVERTED=true

--- a/src/blflc/filesystem.cpp
+++ b/src/blflc/filesystem.cpp
@@ -234,7 +234,7 @@ void loadFileSystem()
         printerConfig.ledConfig.colorOrder = json["ledColorOrder"] | ORDER_GRB;
         printerConfig.ledConfig.wPlacement = json["ledWPlacement"] | W_PLACEMENT_3;
         printerConfig.ledConfig.ledCount = json["ledCount"] | 30;
-        printerConfig.ledConfig.dataPin = json["ledDataPin"] | 16;
+        printerConfig.ledConfig.dataPin = json["ledDataPin"] | DEFAULT_LED_PIN;
         printerConfig.ledConfig.clockPin = json["ledClockPin"] | 0;
 
         // Pattern settings (with defaults for migration)
@@ -263,8 +263,8 @@ void loadFileSystem()
         printerConfig.progressBarBackground = hex2rgb(json["progressBgRGB"] | "#000000");
 
         // Relay settings (with defaults for migration)
-        printerConfig.relayPin = json["relayPin"] | -1;
-        printerConfig.relayInverted = json["relayInverted"] | false;
+        printerConfig.relayPin = json["relayPin"] | DEFAULT_RELAY_PIN;
+        printerConfig.relayInverted = json["relayInverted"] | DEFAULT_RELAY_INVERTED;
 
         LogSerial.println(F("[Filesystem] Loaded config"));
     }

--- a/src/blflc/types.h
+++ b/src/blflc/types.h
@@ -6,6 +6,17 @@ extern "C"
 {
 #endif
 
+    // Hardware defaults (can be overridden via build flags in platformio.ini)
+    #ifndef DEFAULT_LED_PIN
+    #define DEFAULT_LED_PIN 16
+    #endif
+    #ifndef DEFAULT_RELAY_PIN
+    #define DEFAULT_RELAY_PIN -1
+    #endif
+    #ifndef DEFAULT_RELAY_INVERTED
+    #define DEFAULT_RELAY_INVERTED false
+    #endif
+
     // LED strip types supported by FastLED
     enum LedChipType {
         CHIP_WS2812B = 0,
@@ -57,7 +68,7 @@ extern "C"
         uint8_t colorOrder = ORDER_GRB;
         uint8_t wPlacement = W_PLACEMENT_3;  // W channel position for RGBW strips
         uint16_t ledCount = 30;
-        uint8_t dataPin = 16;
+        uint8_t dataPin = DEFAULT_LED_PIN;
         uint8_t clockPin = 0;  // For APA102 only
     } LedConfig;
 
@@ -205,8 +216,8 @@ extern "C"
         bool ledTestMode = false;
 
         // Relay control for LED power
-        int8_t relayPin = -1;           // GPIO pin for relay (-1 = disabled)
-        bool relayInverted = false;     // If true, relay is active HIGH; default is active LOW
+        int8_t relayPin = DEFAULT_RELAY_PIN;       // GPIO pin for relay (-1 = disabled)
+        bool relayInverted = DEFAULT_RELAY_INVERTED;  // If true, relay is active LOW
 
     } PrinterConfig;
 


### PR DESCRIPTION
- Refactor platformio.ini to use inheritance ([env] base, extends)
- Remove duplicated config (115→101 lines, version now in one place)
- Remove unused custom_project_codename settings
- Add build-time hardware defaults for LED and relay pins:
  - esp32dev: LED=16, relay disabled
  - esp32_eth_gledopto: LED=16, relay=18 (inverted)
  - esp32_eth_iotorero: LED=5, relay=2 (inverted)
- Update types.h with DEFAULT_* defines and fallbacks
- Update filesystem.cpp to use defines for config loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)